### PR TITLE
Add code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: node_js
 node_js:
   - "stable"
   - "4.2.3"
+script:
+  - npm test
+  - npm run cover
+  - npm run _send_to_coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ script:
   - npm test
   - npm run cover
   - npm run _send_to_coveralls
+  - npm run _send_to_codeclimate

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # aws-backup-manager
 Automatically back up EBS volumes using tags
 
-[![Build Status](https://travis-ci.org/Trioxis/aws-backup-manager.svg?branch=master)](https://travis-ci.org/Trioxis/aws-backup-manager) [![Coverage Status](https://coveralls.io/repos/Trioxis/aws-backup-manager/badge.svg?branch=master&service=github)](https://coveralls.io/github/Trioxis/aws-backup-manager?branch=master)
+[![Build Status](https://travis-ci.org/Trioxis/aws-backup-manager.svg?branch=master)](https://travis-ci.org/Trioxis/aws-backup-manager) [![Coverage Status](https://coveralls.io/repos/Trioxis/aws-backup-manager/badge.svg?branch=master&service=github)](https://coveralls.io/github/Trioxis/aws-backup-manager?branch=master) [![Code Climate](https://codeclimate.com/github/Trioxis/aws-backup-manager/badges/gpa.svg)](https://codeclimate.com/github/Trioxis/aws-backup-manager)
 
 ## What does this do?
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # aws-backup-manager
 Automatically back up EBS volumes using tags
 
-[![Build Status](https://travis-ci.org/Trioxis/aws-backup-manager.svg?branch=master)](https://travis-ci.org/Trioxis/aws-backup-manager)
+[![Build Status](https://travis-ci.org/Trioxis/aws-backup-manager.svg?branch=master)](https://travis-ci.org/Trioxis/aws-backup-manager) [![Coverage Status](https://coveralls.io/repos/Trioxis/aws-backup-manager/badge.svg?branch=master&service=github)](https://coveralls.io/github/Trioxis/aws-backup-manager?branch=master)
 
 ## What does this do?
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,21 @@ This will lint the code then run [mocha](http://mochajs.org/). Mocha finds test 
 
 If you only want to lint the code, run
 ```
-npm run lint
+npm run _lint
 ```
+
+### Code Coverage
+
+Code coverage is checked using [isparta](https://github.com/douglasduteil/isparta) by running
+```
+npm run cover
+```
+This outputs a html report in `coverage/` that can be perused in a web browser. It also outputs results to console and in lcov format to send to third party coverage services (see section below)
+
+### Continuous Integration
+
+We're using [Travis CI](https://travis-ci.org/Trioxis/aws-backup-manager) for continuous integration. It runs all tests and sends code coverage information to [Coveralls](https://coveralls.io/github/Trioxis/aws-backup-manager) and [CodeClimate](https://codeclimate.com/github/Trioxis/aws-backup-manager). Check [`.travis.yml`](.travis.yml) for the tasks that are run in CI. 
+
 ## Building
 
 This app is written using [ES6 features](https://github.com/lukehoban/es6features) such as [arrow functions](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Functions/Arrow_functions), [modules](https://hacks.mozilla.org/2015/08/es6-in-depth-modules/) and [Promises](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise). These features are not yet fully implemented in the Node.js engine that runs the app, so it is necessary to compile the code (using [Babel](https://babeljs.io/)) down to ES5.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ This outputs a html report in `coverage/` that can be perused in a web browser. 
 
 ### Continuous Integration
 
-We're using [Travis CI](https://travis-ci.org/Trioxis/aws-backup-manager) for continuous integration. It runs all tests and sends code coverage information to [Coveralls](https://coveralls.io/github/Trioxis/aws-backup-manager) and [CodeClimate](https://codeclimate.com/github/Trioxis/aws-backup-manager). Check [`.travis.yml`](.travis.yml) for the tasks that are run in CI. 
+We're using [Travis CI](https://travis-ci.org/Trioxis/aws-backup-manager) for continuous integration. It runs all tests and sends code coverage information to [Coveralls](https://coveralls.io/github/Trioxis/aws-backup-manager) and [CodeClimate](https://codeclimate.com/github/Trioxis/aws-backup-manager). Check [`.travis.yml`](.travis.yml) for the tasks that are run in CI.
+
+Note: the `CODECLIMATE_REPO_TOKEN` environment variable must be set in Travis CI to successfully send coverage information to CodeClimate
 
 ## Building
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "npm run lint && node ./node_modules/mocha/bin/mocha --compilers js:babel-register",
     "lint": "node ./node_modules/eslint/bin/eslint.js index.js src/**",
     "build": "babel src -d build --source-maps",
-    "start": "node index.js"
+    "start": "node index.js",
+    "cover": "babel-node node_modules/isparta/bin/isparta cover --report text --report html node_modules/mocha/bin/_mocha -- --reporter dot"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-register": "^6.3.13",
     "eslint": "^1.10.3",
     "expect.js": "^0.3.1",
+    "isparta": "^4.0.0",
     "mocha": "^2.3.4",
     "sinon": "^1.17.2"
   },

--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "npm run lint && node ./node_modules/mocha/bin/mocha --compilers js:babel-register",
+    "test": "npm run mocha && npm run coveralls",
+    "mocha": "npm run lint && node ./node_modules/mocha/bin/mocha --compilers js:babel-register",
     "lint": "node ./node_modules/eslint/bin/eslint.js index.js src/**",
     "build": "babel src -d build --source-maps",
     "start": "node index.js",
-    "cover": "babel-node node_modules/isparta/bin/isparta cover --report text --report html node_modules/mocha/bin/_mocha -- --reporter dot"
+    "cover": "babel-node node_modules/isparta/bin/isparta cover --report text --report html node_modules/mocha/bin/_mocha -- --reporter dot",
+    "coveralls": "babel-node node_modules/isparta/bin/isparta cover --report lcovonly node_modules/mocha/bin/_mocha -- --reporter mocha-lcov-reporter && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "repository": {
     "type": "git",
@@ -33,6 +35,7 @@
     "babel-cli": "^6.3.17",
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.3.13",
+    "coveralls": "^2.11.6",
     "eslint": "^1.10.3",
     "expect.js": "^0.3.1",
     "isparta": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "_lint": "node ./node_modules/eslint/bin/eslint.js index.js src/**",
     "_mocha": "node ./node_modules/mocha/bin/mocha --compilers js:babel-register",
     "_send_to_coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
+    "_send_to_codeclimate": "cat ./coverage/lcov.info | node ./node_modules/codeclimate-test-reporter/bin/codeclimate.js",
     "build": "babel src -d build --source-maps",
     "start": "node index.js"
   },
@@ -35,6 +36,7 @@
     "babel-cli": "^6.3.17",
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.3.13",
+    "codeclimate-test-reporter": "^0.1.1",
     "coveralls": "^2.11.6",
     "eslint": "^1.10.3",
     "expect.js": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "npm run mocha && npm run coveralls",
-    "mocha": "npm run lint && node ./node_modules/mocha/bin/mocha --compilers js:babel-register",
-    "lint": "node ./node_modules/eslint/bin/eslint.js index.js src/**",
+    "test": "npm run _lint && npm run _mocha",
+    "cover": "babel-node node_modules/isparta/bin/isparta cover --report text --report html --report lcov node_modules/mocha/bin/_mocha -- --reporter dot",
+    "_lint": "node ./node_modules/eslint/bin/eslint.js index.js src/**",
+    "_mocha": "node ./node_modules/mocha/bin/mocha --compilers js:babel-register",
+    "_send_to_coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "build": "babel src -d build --source-maps",
-    "start": "node index.js",
-    "cover": "babel-node node_modules/isparta/bin/isparta cover --report text --report html node_modules/mocha/bin/_mocha -- --reporter dot",
-    "coveralls": "babel-node node_modules/isparta/bin/isparta cover --report lcovonly node_modules/mocha/bin/_mocha -- --reporter mocha-lcov-reporter && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+    "start": "node index.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "expect.js": "^0.3.1",
     "isparta": "^4.0.0",
     "mocha": "^2.3.4",
+    "mocha-lcov-reporter": "^1.0.0",
     "sinon": "^1.17.2"
   },
   "dependencies": {


### PR DESCRIPTION
Adds code coverage support provided by [isparta](https://github.com/douglasduteil/isparta). Code coverage is output in the `coverage/` directory in json, html and lcov formats and output to console. 

Lcov data is sent to [Coveralls](https://coveralls.io/github/Trioxis/aws-backup-manager) and [CodeClimate](https://codeclimate.com/github/Trioxis/aws-backup-manager/) using packages provided by them. 

npm scripts have been rearranged. A `cover` command has been added and subcommands are prefixed by an `_`. Travis has been configured to take multiple steps during its build and if one command fails, the others will still be carried out 

- [x] Document npm scripts changes
- [x] Document that CodeClimate repo id needs to be set as an env var in Travis