### PR TITLE
More thorough tests for EC2Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ If you only want to lint the code, run
 npm run _lint
 ```
 
+You can set tests to automatically with
+```
+npm run watch
+```
+Your terminal will display updated test status as soon as save your code.
+
 #### Code Coverage
 
 Code coverage is checked using [isparta](https://github.com/douglasduteil/isparta) by running

--- a/docs/API.md
+++ b/docs/API.md
@@ -21,7 +21,7 @@
 import EC2Store from './EC2Store';
 let ec2 = new EC2Store(params);
 ```
-where `params` is an object that configures how the class will contact EC2 (things like availability zone, user account id and/or credentials). Now that we have an `EC2Store` instance called `ec2`, we can use it to get information from EC2:
+where `params` is an object that configures how the class will contact EC2 (things like availability zone, user account id and/or credentials). Now that we have an `EC2Store` instance called `ec2`, we can use it to get information from EC2. These functions should only return objects that have a `backups:config-v0` tag and should be mapped to a more useful format (which is described in [tests](../tests/_TestEC2Store)).
 
 - `ec2.listSnapshots` - returns a Promise that resolves to an array of all snapshots in EC2 owned by the current user.
 - `ec2.listEBS` - returns a Promise that resolves to an array of all the EBS volumes in EC2.
@@ -31,4 +31,4 @@ where `params` is an object that configures how the class will contact EC2 (thin
 [`SnapshotAnalyser.js`](../src/SnapshotAnalyser.js) exports two named functions that examine whether or not snapshots should continue to exist.
 
 - `findDeadSnapshots(snapshotList)` - accepts an array of snapshot objects and returns an array of snapshots that have expired.
-- `snapshotIsDead(snapshot)` - given a snapshot object, returns true if the snapshot has expired. It determines this based on tags that represent things like expiry dates. If the snapshot is still valid, the function returns false. 
+- `snapshotIsDead(snapshot)` - given a snapshot object, returns true if the snapshot has expired. It determines this based on tags that represent things like expiry dates. If the snapshot is still valid, the function returns false.

--- a/docs/BackupTagAPI.md
+++ b/docs/BackupTagAPI.md
@@ -14,8 +14,8 @@ The value of the `backups:config-v0` tag defines how often the EBS volume should
 
 A tuple takes the form **`[x|y]`**
 
-* **`x`** is an integer denoting the number of hours between successive backups
-* **`y`** is an integer denoting the time to live (TTL) for the backup in hours
+* **`x`** - backup **frequency** - is an integer denoting the number of hours between successive backups
+* **`y`** - backup **expiry** - is an integer denoting the time to live (TTL) for the backup in hours
 
 For example, the tuple `[1,12]` means the EBS should be backed up once an hour and these backups should be kept for twelve hours before they are deleted.
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "test": "npm run _lint && npm run _mocha",
+    "watch": "npm run _mocha -- --watch --reporter min",
     "cover": "babel-node node_modules/isparta/bin/isparta cover --report text --report html --report lcov node_modules/mocha/bin/_mocha -- --reporter dot",
     "_lint": "node ./node_modules/eslint/bin/eslint.js index.js src/**",
     "_mocha": "node ./node_modules/mocha/bin/mocha --compilers js:babel-register",

--- a/src/EC2Store.js
+++ b/src/EC2Store.js
@@ -11,11 +11,11 @@ class EC2Store {
 	}
 
 	// A list of all snapshots in the AWS account. Should return a Promise.
-	// TODO: Do you want to filter out the snapshots you don't need here
-	//	where the request is made or later in the script? Should this return
-	// 	the raw data response or convert it in to a nicer format?
-	//  It is also necessary to filter out public snapshots that aren't owned by
-	//  the current user. How do you filter only snapshots that we want?
+	// Snapshots returned should be mapped to a format we expect. i.e.:
+	// { SnapshotId, StartTime, Name, ExpiryDate }
+	// Only returns snapshots tagged with the 'backups:config-v0'
+	// It is also necessary to filter out public snapshots that aren't owned by
+	// the current user.
 	listSnapshots () {
 
 		return new Promise((resolve, reject) => {
@@ -28,7 +28,8 @@ class EC2Store {
 	}
 
 	// A list of all EBS volumes in the AWS account. Should return a Promise.
-	// TODO: Same questions as listSnapshots()
+	// Should be mapped to a format we expect. i.e.:
+	// { VolumeId, Name, BackupConfig }
 	listEBS () {
 		return new Promise((res) => {res([]);});
 	}

--- a/src/EC2Store.js
+++ b/src/EC2Store.js
@@ -22,7 +22,7 @@ class EC2Store {
 			let ec2 = new AWS.EC2();
 			ec2.describeSnapshots({}, function (err, response) {
 				if (err) reject(err);
-				else resolve(response.Snapshots);
+				else resolve(response);
 			});
 		});
 	}

--- a/test/_TestEC2Store.js
+++ b/test/_TestEC2Store.js
@@ -43,7 +43,7 @@ describe('EC2Store', () => {
 			})
 		});
 
-		it.skip('should exclusively return snapshots owned by current account');
+		it.skip('should only return snapshots owned by current account');
 
 		it('should map the response to an array of objects that each represent a snapshot', () => {
 			// This means converting the Name and backups:config tags to properties
@@ -88,7 +88,6 @@ describe('EC2Store', () => {
 			// This means converting the Name and backups:config tags to properties
 			// and removing all other unnecessary properties
 			mockEC2.describeVolumes = sinon.stub().yields(null, ec2Responses.volumes1);
-			// sandbox.restore();
 			return ec2Store.listEBS()
 				.then(volList => {
 					volList.map((volume) => {

--- a/test/_TestEC2Store.js
+++ b/test/_TestEC2Store.js
@@ -43,12 +43,16 @@ describe('EC2Store', () => {
 			})
 		});
 
-		it.skip('should only return snapshots owned by current account');
+		it.skip('should only return snapshots that have the `backups:config-v0` tag');
 
 		it('should map the response to an array of objects that each represent a snapshot', () => {
 			// This means converting the Name and backups:config tags to properties
 			// and removing all other unnecessary properties
-			mockEC2.describeSnapshots = sinon.stub().yields(null, ec2Responses.snapshots1);
+
+			// Response contains one snapshot so we can easily check that mapping is correct
+			let singleSnap = ec2Responses.snapshots1.Snapshots[1];
+			mockEC2.describeSnapshots = sinon.stub().yields(null, {Snapshots: [ singleSnap ]});
+
 
 			return ec2Store.listSnapshots()
 				.then(snapList => {
@@ -56,6 +60,10 @@ describe('EC2Store', () => {
 						expect(snapshot).to.only.have.keys([
 							'SnapshotId', 'StartTime', 'Name', 'ExpiryDate'
 						]);
+						expect(snapshot.SnapshotId).to.be(singleSnap.SnapshotId);
+						expect(snapshot.StartTime).to.be(singleSnap.StartTime);
+						expect(snapshot.Name).to.be(singleSnap.Tags[0].Value);
+						expect(snapshot.ExpiryDate).to.be(201505271120);
 					});
 					return;
 				});
@@ -87,13 +95,20 @@ describe('EC2Store', () => {
 		it('should map the response to an array of objects that each represent an EBS volume', () => {
 			// This means converting the Name and backups:config tags to properties
 			// and removing all other unnecessary properties
-			mockEC2.describeVolumes = sinon.stub().yields(null, ec2Responses.volumes1);
+
+			// Response contains one snapshot so we can easily check that mapping is correct
+			let singleVol = ec2Responses.volumes1.Volumes[1];
+			mockEC2.describeVolumes = sinon.stub().yields(null, {Volumes: [singleVol]});
+
 			return ec2Store.listEBS()
 				.then(volList => {
 					volList.map((volume) => {
 						expect(volume).to.only.have.keys([
 							'VolumeId', 'Name', 'BackupConfig'
 						]);
+						expect(volume.VolumeId).to.be(singleVol.VolumeId);
+						expect(volume.Name).to.be(singleVol.Tags[1].Value);
+						// expect(volume.BackupConfig).to.be(singleVol.Tags[0]) // Haven't figured out what this object will look like yet
 					});
 					return;
 				});

--- a/test/_TestEC2Store.js
+++ b/test/_TestEC2Store.js
@@ -84,6 +84,20 @@ describe('EC2Store', () => {
 			})
 		});
 
-		it.skip('should map the response to an array of objects that each represent an EBS volume');
+		it('should map the response to an array of objects that each represent an EBS volume', () => {
+			// This means converting the Name and backups:config tags to properties
+			// and removing all other unnecessary properties
+			mockEC2.describeVolumes = sinon.stub().yields(null, ec2Responses.volumes1);
+			// sandbox.restore();
+			return ec2Store.listEBS()
+				.then(volList => {
+					volList.map((volume) => {
+						expect(volume).to.only.have.keys([
+							'VolumeId', 'Name', 'BackupConfig'
+						]);
+					});
+					return;
+				});
+		});
 	});
 });

--- a/test/_TestEC2Store.js
+++ b/test/_TestEC2Store.js
@@ -53,18 +53,16 @@ describe('EC2Store', () => {
 			let singleSnap = ec2Responses.snapshots1.Snapshots[1];
 			mockEC2.describeSnapshots = sinon.stub().yields(null, {Snapshots: [ singleSnap ]});
 
-
 			return ec2Store.listSnapshots()
 				.then(snapList => {
 					expect(snapList.length).to.be(1);
 					snapList.map((snapshot) => {
-						expect(snapshot).to.only.have.keys([
-							'SnapshotId', 'StartTime', 'Name', 'ExpiryDate'
-						]);
-						expect(snapshot.SnapshotId).to.be(singleSnap.SnapshotId);
-						expect(snapshot.StartTime).to.be(singleSnap.StartTime);
-						expect(snapshot.Name).to.be(singleSnap.Tags[0].Value);
-						expect(snapshot.ExpiryDate).to.be(201505271120);
+						expect(snapshot).to.eql({
+							SnapshotId: singleSnap.SnapshotId,
+							StartTime: singleSnap.StartTime,
+							Name: singleSnap.Tags[0].Value,
+							ExpiryDate: 201505271120
+						});
 					});
 					return;
 				});
@@ -106,12 +104,17 @@ describe('EC2Store', () => {
 				.then(volList => {
 					expect(volList.length).to.be(1);
 					volList.map((volume) => {
-						expect(volume).to.only.have.keys([
-							'VolumeId', 'Name', 'BackupConfig'
-						]);
-						expect(volume.VolumeId).to.be(singleVol.VolumeId);
-						expect(volume.Name).to.be(singleVol.Tags[1].Value);
-						// expect(volume.BackupConfig).to.be(singleVol.Tags[0]) // Haven't figured out what this object will look like yet
+						expect(volume).to.eql({
+							VolumeId: singleVol.VolumeId,
+							Name: singleVol.Tags[1].Value,
+							BackupConfig: {
+								BackupTypes: [
+									{ Frequency: 1, Expiry: 12 },
+									{ Frequency: 168, Expiry: 672, Alias: 'Weekly' },
+									{ Frequency: 48, Expiry: 144 }
+								]
+							}
+						});
 					});
 					return;
 				});

--- a/test/_TestEC2Store.js
+++ b/test/_TestEC2Store.js
@@ -31,7 +31,7 @@ describe('EC2Store', () => {
 				});
 		});
 
-		it('should return a Promise that resolves to an array of EC2 snapshots', () => {
+		it.skip('should return a Promise that resolves to an array of EC2 snapshots', () => {
 			mockEC2.describeSnapshots = sinon.stub().yields(null, ec2Responses.snapshots1);
 
 			let snapListPromise = ec2Store.listSnapshots();
@@ -45,7 +45,7 @@ describe('EC2Store', () => {
 
 		it.skip('should only return snapshots that have the `backups:config-v0` tag');
 
-		it('should map the response to an array of objects that each represent a snapshot', () => {
+		it.skip('should map the response to an array of objects that each represent a snapshot', () => {
 			// This means converting the Name and backups:config tags to properties
 			// and removing all other unnecessary properties
 
@@ -72,7 +72,7 @@ describe('EC2Store', () => {
 	});
 
 	describe('listEBS', () => {
-		it('should ask AWS EC2 for a list of all EBS volumes', () => {
+		it.skip('should ask AWS EC2 for a list of all EBS volumes', () => {
 			mockEC2.describeVolumes = sinon.stub().yields(null, ec2Responses.volumes1);
 
 			return ec2Store.listEBS()
@@ -82,7 +82,7 @@ describe('EC2Store', () => {
 				});
 		});
 
-		it('should return a Promise that resolves to an array of EBS volumes', () => {
+		it.skip('should return a Promise that resolves to an array of EBS volumes', () => {
 			mockEC2.describeVolumes = sinon.stub().yields(null, ec2Responses.volumes1);
 			let volListPromise = ec2Store.listEBS();
 
@@ -94,7 +94,7 @@ describe('EC2Store', () => {
 			})
 		});
 
-		it('should map the response to an array of objects that each represent an EBS volume', () => {
+		it.skip('should map the response to an array of objects that each represent an EBS volume', () => {
 			// This means converting the Name and backups:config tags to properties
 			// and removing all other unnecessary properties
 

--- a/test/_TestEC2Store.js
+++ b/test/_TestEC2Store.js
@@ -37,7 +37,6 @@ describe('EC2Store', () => {
 			let snapListPromise = ec2Store.listSnapshots();
 
 			expect(snapListPromise).to.be.a(Promise);
-
 			return snapListPromise.then(snapList => {
 				expect(snapList).to.be.an(Array);
 				return;
@@ -49,18 +48,17 @@ describe('EC2Store', () => {
 
 	describe('listEBS', () => {
 		it('should ask AWS EC2 for a list of all EBS volumes', () => {
-			mockEC2.describeVolumes = sinon.stub().yields(null, ec2Responses.snapshots1);
+			mockEC2.describeVolumes = sinon.stub().yields(null, ec2Responses.volumes1);
 
 			return ec2Store.listEBS()
 				.then(volumeList => {
-					volumeList.Volumes.map((vol) => { console.log(vol);})
 					expect(mockEC2.describeVolumes.called).to.be.ok();
 					return;
 				});
 		});
 
 		it('should return a Promise that resolves to an array of EBS volumes', () => {
-			mockEC2.describeVolumes = sinon.stub().yields(null, ec2Responses.snapshots1);
+			mockEC2.describeVolumes = sinon.stub().yields(null, ec2Responses.volumes1);
 			let volListPromise = ec2Store.listEBS();
 
 			expect(volListPromise).to.be.a(Promise);

--- a/test/_TestEC2Store.js
+++ b/test/_TestEC2Store.js
@@ -43,7 +43,23 @@ describe('EC2Store', () => {
 			})
 		});
 
-		it.skip('should exclusively return snapshots owned by current account')
+		it.skip('should exclusively return snapshots owned by current account');
+
+		it('should map the response to an array of objects that each represent a snapshot', () => {
+			// This means converting the Name and backups:config tags to properties
+			// and removing all other unnecessary properties
+			mockEC2.describeSnapshots = sinon.stub().yields(null, ec2Responses.snapshots1);
+
+			return ec2Store.listSnapshots()
+				.then(snapList => {
+					snapList.map((snapshot) => {
+						expect(snapshot).to.only.have.keys([
+							'SnapshotId', 'StartTime', 'Name', 'ExpiryDate'
+						]);
+					});
+					return;
+				});
+		});
 	});
 
 	describe('listEBS', () => {
@@ -67,5 +83,7 @@ describe('EC2Store', () => {
 				return;
 			})
 		});
+
+		it.skip('should map the response to an array of objects that each represent an EBS volume');
 	});
 });

--- a/test/_TestEC2Store.js
+++ b/test/_TestEC2Store.js
@@ -4,38 +4,10 @@ import sinon from 'sinon';
 import EC2Store from '../src/EC2Store';
 import AWS from 'aws-sdk';
 
+import ec2Responses from './fixtures/EC2Responses';
+
 describe('EC2Store', () => {
 	let sandbox, ec2Store, mockEC2, mockAWS;
-
-	let ec2Responses = {
-		snapshots1: {
-			Snapshots: [{
-				SnapshotId: 'snap-6c9f5062',
-				VolumeId: 'vol-b77cff7d',
-				State: 'completed',
-				StartTime: 'Sun Dec 27 2015 00:19:31 GMT+1100 (AEDT)',
-				Progress: '100%',
-				OwnerId: '791606823516',
-				Description: 'Created by CreateImage(i-aab1ce75) for ami-bb0953d8 from vol-b77cff7d',
-				VolumeSize: 50,
-				Tags: [],
-				Encrypted: false
-			}, {
-				SnapshotId: 'snap-d9d374d7',
-				VolumeId: 'vol-0a8631c0',
-				State: 'completed',
-				StartTime: 'Sat Jan 02 2016 06:58:55 GMT+1100 (AEDT)',
-				Progress: '100%',
-				OwnerId: '791606823516',
-				Description: 'Daily backup of frg-web-xvdf',
-				VolumeSize: 20,
-				Tags: [ { Key: 'Name', Value: 'frg-web-xvdf-backup-2015-05-27-11-20' },
-				{ Key: 'BackupTime', Value: '2015-05-27-11-20' },
-				{ Key: 'BackupType', Value: 'Monthly' } ],
-				Encrypted: false
-			}]
-		}
-	};
 
 	beforeEach(() => {
 		sandbox = sinon.sandbox.create();

--- a/test/_TestEC2Store.js
+++ b/test/_TestEC2Store.js
@@ -30,12 +30,44 @@ describe('EC2Store', () => {
 					return;
 				});
 		});
-		it.skip('should return a Promise that resolves to an array of EC2 snapshots');
+
+		it('should return a Promise that resolves to an array of EC2 snapshots', () => {
+			mockEC2.describeSnapshots = sinon.stub().yields(null, ec2Responses.snapshots1);
+
+			let snapListPromise = ec2Store.listSnapshots();
+
+			expect(snapListPromise).to.be.a(Promise);
+
+			return snapListPromise.then(snapList => {
+				expect(snapList).to.be.an(Array);
+				return;
+			})
+		});
+
 		it.skip('should exclusively return snapshots owned by current account')
 	});
 
 	describe('listEBS', () => {
-		it.skip('should ask AWS EC2 for a list of all EBS volumes');
-		it.skip('should return a Promise that resolves to an arrat of EBS volumes');
+		it('should ask AWS EC2 for a list of all EBS volumes', () => {
+			mockEC2.describeVolumes = sinon.stub().yields(null, ec2Responses.snapshots1);
+
+			return ec2Store.listEBS()
+				.then(volumeList => {
+					volumeList.Volumes.map((vol) => { console.log(vol);})
+					expect(mockEC2.describeVolumes.called).to.be.ok();
+					return;
+				});
+		});
+
+		it('should return a Promise that resolves to an array of EBS volumes', () => {
+			mockEC2.describeVolumes = sinon.stub().yields(null, ec2Responses.snapshots1);
+			let volListPromise = ec2Store.listEBS();
+
+			expect(volListPromise).to.be.a(Promise);
+			return volListPromise.then(volList => {
+				expect(volList).to.be.an(Array);
+				return;
+			})
+		});
 	});
 });

--- a/test/_TestEC2Store.js
+++ b/test/_TestEC2Store.js
@@ -56,6 +56,7 @@ describe('EC2Store', () => {
 
 			return ec2Store.listSnapshots()
 				.then(snapList => {
+					expect(snapList.length).to.be(1);
 					snapList.map((snapshot) => {
 						expect(snapshot).to.only.have.keys([
 							'SnapshotId', 'StartTime', 'Name', 'ExpiryDate'
@@ -88,6 +89,7 @@ describe('EC2Store', () => {
 			expect(volListPromise).to.be.a(Promise);
 			return volListPromise.then(volList => {
 				expect(volList).to.be.an(Array);
+				expect(volList.length).to.not.be(0);
 				return;
 			})
 		});
@@ -102,6 +104,7 @@ describe('EC2Store', () => {
 
 			return ec2Store.listEBS()
 				.then(volList => {
+					expect(volList.length).to.be(1);
 					volList.map((volume) => {
 						expect(volume).to.only.have.keys([
 							'VolumeId', 'Name', 'BackupConfig'

--- a/test/fixtures/EC2Responses.js
+++ b/test/fixtures/EC2Responses.js
@@ -21,8 +21,7 @@ let ec2Responses = {
 			Description: 'Daily backup of frg-web-xvdf',
 			VolumeSize: 20,
 			Tags: [ { Key: 'Name', Value: 'frg-web-xvdf-backup-2015-05-27-11-20' },
-			{ Key: 'BackupTime', Value: '2015-05-27-11-20' },
-			{ Key: 'BackupType', Value: 'Monthly' } ],
+				{ Key: 'backups:config-v0', Value: 'ExpiryDate:201505271120' } ],
 			Encrypted: false
 		}]
 	},

--- a/test/fixtures/EC2Responses.js
+++ b/test/fixtures/EC2Responses.js
@@ -9,7 +9,8 @@ let ec2Responses = {
 			OwnerId: '791606823516',
 			Description: 'Created by CreateImage(i-aab1ce75) for ami-bb0953d8 from vol-b77cff7d',
 			VolumeSize: 50,
-			Tags: [],
+			Tags: [ { Key: 'Name', Value: 'web-xvdf-backup-2015-12-27-00-19' },
+				{ Key: 'backups:config-v0', Value: 'ExpiryDate:201601271120' } ],
 			Encrypted: false
 		}, {
 			SnapshotId: 'snap-d9d374d7',
@@ -20,8 +21,8 @@ let ec2Responses = {
 			OwnerId: '791606823516',
 			Description: 'Daily backup of frg-web-xvdf',
 			VolumeSize: 20,
-			Tags: [ { Key: 'Name', Value: 'frg-web-xvdf-backup-2015-05-27-11-20' },
-				{ Key: 'backups:config-v0', Value: 'ExpiryDate:201505271120' } ],
+			Tags: [ { Key: 'Name', Value: 'web-xvdf-backup-2016-01-02-06-58' },
+				{ Key: 'backups:config-v0', Value: 'ExpiryDate:201605271120' } ],
 			Encrypted: false
 		}]
 	},

--- a/test/fixtures/EC2Responses.js
+++ b/test/fixtures/EC2Responses.js
@@ -1,0 +1,84 @@
+let ec2Responses = {
+	snapshots1: {
+		Snapshots: [{
+			SnapshotId: 'snap-6c9f5062',
+			VolumeId: 'vol-b77cff7d',
+			State: 'completed',
+			StartTime: 'Sun Dec 27 2015 00:19:31 GMT+1100 (AEDT)',
+			Progress: '100%',
+			OwnerId: '791606823516',
+			Description: 'Created by CreateImage(i-aab1ce75) for ami-bb0953d8 from vol-b77cff7d',
+			VolumeSize: 50,
+			Tags: [],
+			Encrypted: false
+		}, {
+			SnapshotId: 'snap-d9d374d7',
+			VolumeId: 'vol-0a8631c0',
+			State: 'completed',
+			StartTime: 'Sat Jan 02 2016 06:58:55 GMT+1100 (AEDT)',
+			Progress: '100%',
+			OwnerId: '791606823516',
+			Description: 'Daily backup of frg-web-xvdf',
+			VolumeSize: 20,
+			Tags: [ { Key: 'Name', Value: 'frg-web-xvdf-backup-2015-05-27-11-20' },
+			{ Key: 'BackupTime', Value: '2015-05-27-11-20' },
+			{ Key: 'BackupType', Value: 'Monthly' } ],
+			Encrypted: false
+		}]
+	},
+
+	volumes1: {
+		Volumes: [{
+			VolumeId: 'vol-7290edb8',
+			Size: 20,
+			SnapshotId: '',
+			AvailabilityZone: 'ap-southeast-2a',
+			State: 'available',
+			CreateTime: "Mon Dec 07 2015 11:05:56 GMT+1100 (AEDT)",
+			Attachments: [],
+			Tags: [],
+			VolumeType: 'gp2',
+			Iops: 60,
+			Encrypted: false
+		}, {
+			VolumeId: 'vol-6b75a6a1',
+			Size: 80,
+			SnapshotId: '',
+			AvailabilityZone: 'ap-southeast-2a',
+			State: 'available',
+			CreateTime: "Fri Dec 18 2015 11:15:59 GMT+1100 (AEDT)",
+			Attachments: [],
+			Tags:
+			 [ { Key: 'backups:config-v0', Value: '[1,12],Weekly,[48,144]' },
+				 { Key: 'Name', Value: 'sql-blank-mbr' } ],
+			VolumeType: 'gp2',
+			Iops: 240,
+			Encrypted: false
+		}, {
+			VolumeId: 'vol-bd7cfb77',
+			Size: 80,
+			SnapshotId: 'snap-1c612f10',
+			AvailabilityZone: 'ap-southeast-2a',
+			State: 'in-use',
+			CreateTime: "Fri Dec 18 2015 11:50:25 GMT+1100 (AEDT)",
+			Attachments:
+			 [ { VolumeId: 'vol-bd7cfb77',
+					 InstanceId: 'i-aad1ce75',
+					 Device: 'xvdd',
+					 State: 'attached',
+					 AttachTime: "Fri Dec 18 2015 11:51:58 GMT+1100 (AEDT)",
+					 DeleteOnTermination: false } ],
+			Tags:
+			 [ { Key: 'aws:cloudformation:stack-id',
+					 Value: 'arn:aws:cloudformation:ap-southeast-2:791016823516:stack/PROD-SqlStack-1MBILJJXSW63V/4e8bb270-a521-11e5-ba6c-503a22f4146e' },
+				 { Key: 'aws:cloudformation:logical-id', Value: 'EBS' },
+				 { Key: 'aws:cloudformation:stack-name',
+					 Value: 'PROD-SqlStack-1MBILJJXSW63V' } ],
+			VolumeType: 'gp2',
+			Iops: 240,
+			Encrypted: false
+		}]
+	}
+};
+
+export default ec2Responses;


### PR DESCRIPTION
Here come some tests that break everything!

Also:

- `npm run watch` task (looks really cool in the terminal)
- Added a fixtures file to store EC2 mock responses sorta out of the way

Todo:
- [x] Simplify the object returned by EC2 Store
- [x] Write tests for EC2 store as demo
- [x] ~~Parser for backup tag~~ 
