### PR TITLE
Provide useful user feedback (Fixes #8)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -23,7 +23,7 @@ let ec2 = new EC2Store(params);
 ```
 where `params` is an object that configures how the class will contact EC2 (things like availability zone, user account id and/or credentials). Now that we have an `EC2Store` instance called `ec2`, we can use it to get information from EC2. These functions should only return EC2 objects that have a `backups:config-v0` tag and should be mapped to a more useful format (which is described in [tests](../test/_TestEC2Store.js)).
 
-`ec2.listSnapshots` - returns a Promise that resolves to an array of all snapshots in EC2 with a tag named `backups:config-v0`. The array contains snapshot objects of the form
+`ec2.listSnapshots` - returns object of the form `{snapshots, warnings}`. `snapshots` is a Promise that resolves to an array of all snapshots in EC2 with a tag named `backups:config-v0`. The array contains snapshot objects of the form
 ```
 { SnapshotId, Name, StartTime, ExpiryDate, Tags }
 ```
@@ -34,7 +34,7 @@ where `params` is an object that configures how the class will contact EC2 (thin
 * `Tags` is an object mapped from the EC2 tags on the volume. Properties on the `Tags` object are named according to the tag `key` and have the tag value
 
 
-`ec2.listEBS` - returns a Promise that resolves to an array of all the EBS volumes in EC2 that have a tag named `backups:config-v0`. The array contains volume objects of the form
+`ec2.listEBS` - returns an object of the form `{volumes, warnings}`. `volumes` is a Promise that resolves to an array of all the EBS volumes in EC2 that have a tag named `backups:config-v0`. The array contains volume objects of the form
 ```
 { VolumeId, Name, BackupConfig, Tags }
 ```
@@ -43,6 +43,8 @@ where `params` is an object that configures how the class will contact EC2 (thin
 * `BackupConfig` is an object with property `BackupTypes`
     * `BackupTypes` is an array of objects mapped from the `backups:config-v0` tag. They have the form `{Frequency: x, Expiry: y, Alias: 'AliasName'}` (see the [Backup Tag API](./BackupTagAPI.md) for details). The `Alias` property is optional.
 * `Tags` is an object mapped from the EC2 tags on the volume. Properties on the `Tags` object are named according to the tag `key` and have the tag value
+
+The `warnings` property of the above objects is an array of strings that describe problems that occurred while parsing EC2 objects.
 
 ## SnapshotAnalyser
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -23,7 +23,7 @@ let ec2 = new EC2Store(params);
 ```
 where `params` is an object that configures how the class will contact EC2 (things like availability zone, user account id and/or credentials). Now that we have an `EC2Store` instance called `ec2`, we can use it to get information from EC2. These functions should only return EC2 objects that have a `backups:config-v0` tag and should be mapped to a more useful format (which is described in [tests](../test/_TestEC2Store.js)).
 
-`ec2.listSnapshots` - returns object of the form `{snapshots, warnings}`. `snapshots` is a Promise that resolves to an array of all snapshots in EC2 with a tag named `backups:config-v0`. The array contains snapshot objects of the form
+`ec2.listSnapshots` - returns a Promised object of the form `{snapshots, warnings}`. `snapshots` is an array of all snapshots in EC2 with a tag named `backups:config-v0`. The array contains snapshot objects of the form
 ```
 { SnapshotId, Name, StartTime, ExpiryDate, Tags }
 ```
@@ -34,7 +34,7 @@ where `params` is an object that configures how the class will contact EC2 (thin
 * `Tags` is an object mapped from the EC2 tags on the volume. Properties on the `Tags` object are named according to the tag `key` and have the tag value
 
 
-`ec2.listEBS` - returns an object of the form `{volumes, warnings}`. `volumes` is a Promise that resolves to an array of all the EBS volumes in EC2 that have a tag named `backups:config-v0`. The array contains volume objects of the form
+`ec2.listEBS` - returns a Promised object of the form `{volumes, warnings}`. `volumes` is a array of all the EBS volumes in EC2 that have a tag named `backups:config-v0`. The array contains volume objects of the form
 ```
 { VolumeId, Name, BackupConfig, Tags }
 ```

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@
 [`ActionCreator.js`](../src/ActionCreator.js) exports three named functions. They all return objects that represent an action to be used by the `Actioner`
 
 - `makeDeleteAction(snap)` - accepts an object that represents a snapshot in EC2. It returns an object that represents an action that will delete the snapshot.
-- `makeCreateAction(volume, snapList)` - accepts an object that represents an EBS volume and an array of snapshot objects that exist in EC2. Returns an array of actions that will create the required backup snapshots for the EBS volume.
+- `makeCreationActions(volume, snapList)` - accepts an object that represents an EBS volume and an array of snapshot objects that exist in EC2. Returns an array of actions that will create the required backup snapshots for the EBS volume.
 - `determineBackupsNeeded(volume, snapList)` - accepts an EBS volume object and an array of snapshot objects. This simply determines that types of snapshots required and returns them as an array. This should be used by `makeCreateAction` to figure out what creation actions it needs to make.
 
 ## Actioner

--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 var BackupRunner = require('./build/');
 
 console.log('Runnning the backup script in ./build/');
+console.log();
 BackupRunner.default().then((result) => {
+	console.log();
 	console.log('DONE');
-	console.log('Printing output:');
-	console.log(result);
+	// console.log('Printing output:');
+	// console.log(result);
 	console.log('Exiting');
 });

--- a/index.js
+++ b/index.js
@@ -2,10 +2,7 @@ var BackupRunner = require('./build/');
 
 console.log('Runnning the backup script in ./build/');
 console.log();
-BackupRunner.default().then((result) => {
+BackupRunner.default().then(() => {
 	console.log();
-	console.log('DONE');
-	// console.log('Printing output:');
-	// console.log(result);
-	console.log('Exiting');
+	console.log('Done, Exiting');
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-backup-manager",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Automatically back up EBS volumes using tags",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "_send_to_codecov": "./node_modules/codecov/bin/codecov",
     "_send_to_codeclimate": "cat ./coverage/lcov.info | node ./node_modules/codeclimate-test-reporter/bin/codeclimate.js",
     "build": "babel src -d build --source-maps",
-    "start": "node index.js"
+    "start": "npm run build >/dev/null && node index.js"
   },
   "repository": {
     "type": "git",

--- a/src/ActionCreator.js
+++ b/src/ActionCreator.js
@@ -6,17 +6,17 @@ let makeDeleteAction = (snap) => {
 
 // Given an EBS volume and a list of snapshots, return a list of actions
 // to create the necessary snapshots that fulful the backup requirements
-let makeCreateAction = (volume, snapList) => {
+let makeCreationActions = (volume, snapList) => {
 
 	return determineBackupsNeeded(volume, snapList).map(backup => backup);
 };
 
 // Read the tags on the EBS volume and check if the backup requirements are
 // fulfilled by the current state of snapshots. For example: if the volume
-// requires hourly and daily backups, do hourly and daily snapshots exist 
+// requires hourly and daily backups, do hourly and daily snapshots exist
 // within the last hour and 24 hours respectively?
 let determineBackupsNeeded = (volume, snapList) => {
-	return {volume, snapList};
+	return [{volume, snapList}];
 };
 
-export {makeDeleteAction, makeCreateAction, determineBackupsNeeded};
+export {makeDeleteAction, makeCreationActions, determineBackupsNeeded};

--- a/src/EC2Store.js
+++ b/src/EC2Store.js
@@ -91,7 +91,7 @@ class EC2Store {
 						});
 						return snap;
 					});
-					resolve({snapshots: snapshots, warnings: warnings});
+					resolve({snapshots, warnings});
 				}
 			});
 		});
@@ -177,7 +177,7 @@ class EC2Store {
 
 						return true;
 					});
-					resolve({volumes: volumes, warnings: warnings});
+					resolve({volumes, warnings});
 				}
 			});
 		});

--- a/src/EC2Store.js
+++ b/src/EC2Store.js
@@ -80,10 +80,10 @@ class EC2Store {
 									if (moment(value, EXPIRY_DATE_FORMAT).isValid()) {
 										snap.ExpiryDate = parseInt(value);
 									} else {
-										warnings.push(`Snapshot ${prettyPrintSnap(snap)}: Value for ExpiryDate '${value}' is not a valid date in ${EXPIRY_DATE_FORMAT} format. Check the '${BACKUP_API_TAG}' tag is valid`);
+										warnings.push(`Snapshot ${prettyPrintSnap(snap)}: ExpiryDate set to undefined because the parsed value '${value}' is not a valid date in ${EXPIRY_DATE_FORMAT} format. Check the ExpiryDate in '${BACKUP_API_TAG}' is valid`);
 									}
 								} else {
-									warnings.push(`Snapshot ${prettyPrintSnap(snap)}: Found invalid value '${value}' for ExpiryDate. Check the '${BACKUP_API_TAG}' is valid and ExpiryDate is in ${EXPIRY_DATE_FORMAT} format`);
+									warnings.push(`Snapshot ${prettyPrintSnap(snap)}: ExpiryDate set to undefined beacuse the parsed value '${value}' is invalid. Check the '${BACKUP_API_TAG}' tag is valid and ExpiryDate is in ${EXPIRY_DATE_FORMAT} format`);
 								}
 							} else {
 								warnings.push(`Snapshot ${prettyPrintSnap(snap)}: Unknown '${BACKUP_API_TAG}' parameter: '${backupParam}'`);

--- a/src/EC2Store.js
+++ b/src/EC2Store.js
@@ -76,7 +76,7 @@ class EC2Store {
 							// Check the expiry date is in YYYYMMDDHHmmss format (14 digits)
 							snap.ExpiryDate = undefined;
 							if (key === 'ExpiryDate') {
-								if (/^\d{14}$/.test(value)) {
+								if (new RegExp(`^\\d{${EXPIRY_DATE_FORMAT.length}}$`).test(value)) {
 									if (moment(value, EXPIRY_DATE_FORMAT).isValid()) {
 										snap.ExpiryDate = parseInt(value);
 									} else {

--- a/src/index.js
+++ b/src/index.js
@@ -44,5 +44,6 @@ export default function () {
 		}).catch(err => {
 			console.error();
 			printer.printError(err);
+			process.exit(1);
 		});
 }

--- a/src/index.js
+++ b/src/index.js
@@ -41,5 +41,8 @@ export default function () {
 					printer.printStatistics(collector.stats);
 					printer.printWarnings(collector.warnings);
 				});
-		}).catch(err => console.error(err));
+		}).catch(err => {
+			console.error();
+			printer.printError(err);
+		});
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,20 +4,48 @@ import {makeDeleteAction, makeCreationActions} from './ActionCreator';
 import {doActions} from './Actioner';
 
 export default function () {
+	let collector = {
+		warnings: [],
+		stats: {
+			snapshots: 0,
+			volumes: 0,
+			backupTypes: 0
+		}
+	};
+
 	let ec2 = new EC2Store();
 
 	return ec2.listSnapshots()
-		.then(snapList => {
-			let deadSnaps = findDeadSnapshots(snapList);
+		.then(({snapshots, warnings}) => {
+			collector.stats.snapshots += snapshots.length;
+			collector.warnings = collector.warnings.concat(warnings);
+			let deadSnaps = findDeadSnapshots(snapshots);
 			let cleanupActions = deadSnaps.map(snap => makeDeleteAction(snap));
 
 			let creationActions = ec2.listEBS()
-				.then(ebsList => {
-					return ebsList.map(volume => makeCreationActions(volume, snapList));
+				.then(({volumes, warnings}) => {
+					collector.stats.volumes += volumes.length;
+					volumes.map((volume) => collector.stats.backupTypes += volume.BackupConfig.BackupTypes.length)
+					collector.warnings = collector.warnings.concat(warnings);
+					return volumes.map(volume => makeCreationActions(volume, snapshots));
 				});
 
 			return Promise.all([cleanupActions, creationActions])
 				.then(actionsArray => actionsArray[0].concat(actionsArray[1]))
-				.then(action => doActions(action));
+				.then(action => doActions(action))
+				.then(() => {
+					let headingLine = '-------------------------------------------------------------';
+					console.log('AWSBM Statistics');
+					console.log(headingLine);
+					console.log(`${collector.stats.snapshots} snapshots`);
+					console.log(`${collector.stats.volumes} EBS volumes`);
+					console.log(`${collector.stats.backupTypes} volume backup types identified`);
+					console.log();
+					if (collector.warnings.length > 0) {
+						console.warn(`${collector.warnings.length} warnings`);
+						console.log(headingLine);
+						collector.warnings.map((warning) => console.warn(` - ${warning}`));
+					}
+				});
 		}).catch(err => console.error(err));
 }

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ export default function () {
 			printer.printSnaplist(snapshots);
 			collector.stats.snapshots += snapshots.length;
 			collector.warnings = collector.warnings.concat(warnings);
+
 			let deadSnaps = findDeadSnapshots(snapshots);
 			let cleanupActions = deadSnaps.map(snap => makeDeleteAction(snap));
 
@@ -31,6 +32,7 @@ export default function () {
 					collector.stats.volumes += volumes.length;
 					volumes.map((volume) => collector.stats.backupTypes += volume.BackupConfig.BackupTypes.length);
 					collector.warnings = collector.warnings.concat(warnings);
+					
 					return volumes.map(volume => makeCreationActions(volume, snapshots));
 				});
 
@@ -42,7 +44,6 @@ export default function () {
 					printer.printWarnings(collector.warnings);
 				});
 		}).catch(err => {
-			console.error();
 			printer.printError(err);
 			process.exit(1);
 		});

--- a/src/index.js
+++ b/src/index.js
@@ -8,15 +8,11 @@ export default function () {
 
 	return ec2.listSnapshots()
 		.then(snapList => {
-			console.log('AWSBM: All backup snapshots:');
-			console.log(snapList);
 			let deadSnaps = findDeadSnapshots(snapList);
 			let cleanupActions = deadSnaps.map(snap => makeDeleteAction(snap));
 
 			let creationActions = ec2.listEBS()
 				.then(ebsList => {
-					console.log('AWSBM: All volumes to backup:');
-					console.log(ebsList);
 					return ebsList.map(volume => makeCreationActions(volume, snapList));
 				});
 

--- a/src/printing.js
+++ b/src/printing.js
@@ -1,0 +1,55 @@
+import moment from 'moment';
+
+let headingLine = '-------------------------------------------------------------';
+
+var printSnaplist = (snapshots) => {
+	console.log('AWSBM Snapshots');
+	console.log(headingLine);
+	snapshots.map(snap => {
+		console.log(`(${snap.SnapshotId}): '${snap.Name}'`);
+		let _ =  snap.SnapshotId.replace(/./g, ' ') + '    ';
+		console.log(`${_} Created: ${snap.StartTime}`);
+		console.log(`${_} Expires: ${snap.ExpiryDate ? moment(snap.ExpiryDate, 'YYYYMMDDHHmmss').fromNow() : 'Never'}`);
+	});
+	console.log();
+};
+
+var printEBSList = (volumes) => {
+	console.log('AWSBM Volumes');
+	console.log(headingLine);
+	volumes.map(vol => {
+		console.log(`(${vol.VolumeId}): '${vol.Name}'`);
+		let _ =  vol.VolumeId.replace(/./g, ' ') + '    ';
+		vol.BackupConfig.BackupTypes.map(backup => {
+			let name = `${backup.Alias ? `${backup.Alias} `: ''}backup`;
+			let frequencyDescriptor = `${moment.duration(backup.Frequency, 'hours').humanize().replace(/(a )|(an )/g, '')} for ${moment.duration(backup.Expiry, 'hours').humanize()}`;
+			let numberAtATime = `${Math.floor(backup.Expiry/backup.Frequency)} backups at a time`;
+			console.log(`${_} Backup: ${numberAtATime} (${name} every ${frequencyDescriptor})`);
+		});
+	});
+	console.log();
+};
+
+var printStatistics = (stats) => {
+	console.log('AWSBM Statistics');
+	console.log(headingLine);
+	console.log(`${stats.snapshots} snapshots`);
+	console.log(`${stats.volumes} EBS volumes`);
+	console.log(`${stats.backupTypes} volume backup types identified`);
+	console.log();
+};
+
+var printWarnings = (warnings) => {
+	if (warnings.length > 0) {
+		console.warn(`${warnings.length} warnings`);
+		console.warn(headingLine);
+		warnings.map((warning) => console.warn(` - ${warning}`));
+	}
+};
+
+export {
+	printSnaplist,
+	printEBSList,
+	printStatistics,
+	printWarnings
+};

--- a/src/printing.js
+++ b/src/printing.js
@@ -48,6 +48,7 @@ var printWarnings = (warnings) => {
 };
 
 var printError = (error) => {
+	console.error();
 	console.error('Error');
 	console.error(headingLine);
 	console.error(error.stack);

--- a/src/printing.js
+++ b/src/printing.js
@@ -47,9 +47,16 @@ var printWarnings = (warnings) => {
 	}
 };
 
+var printError = (error) => {
+	console.error('Error');
+	console.error(headingLine);
+	console.error(error.stack);
+};
+
 export {
 	printSnaplist,
 	printEBSList,
 	printStatistics,
-	printWarnings
+	printWarnings,
+	printError
 };

--- a/test/_TestEC2Store.js
+++ b/test/_TestEC2Store.js
@@ -37,8 +37,8 @@ describe('EC2Store', () => {
 			let snapListPromise = ec2Store.listSnapshots();
 
 			expect(snapListPromise).to.be.a(Promise);
-			return snapListPromise.then(snapList => {
-				expect(snapList).to.be.an(Array);
+			return snapListPromise.then(({snapshots}) => {
+				expect(snapshots).to.be.an(Array);
 				return;
 			})
 		});
@@ -52,9 +52,9 @@ describe('EC2Store', () => {
 			mockEC2.describeSnapshots = sinon.stub().yields(null, ec2Responses.snapshots1);
 
 			return ec2Store.listSnapshots()
-				.then(snapList => {
-					expect(snapList.length).to.be(2);
-					expect(snapList).to.eql([
+				.then(({snapshots}) => {
+					expect(snapshots.length).to.be(2);
+					expect(snapshots).to.eql([
 						{
 							ExpiryDate: "20160127112018",
 							Name: "web-xvdf-backup-2015-12-27-00-19",
@@ -84,9 +84,9 @@ describe('EC2Store', () => {
 			mockEC2.describeSnapshots = sinon.stub().yields(null, ec2Responses.snapshots2);
 
 			return ec2Store.listSnapshots()
-				.then(snapList => {
-					expect(snapList.length).to.be(3);
-					expect(snapList).to.eql([
+				.then(({snapshots}) => {
+					expect(snapshots.length).to.be(3);
+					expect(snapshots).to.eql([
 						{
 							ExpiryDate: undefined,
 							Name: "web-xvdf-backup-2015-12-27-00-19",
@@ -131,7 +131,7 @@ describe('EC2Store', () => {
 			mockEC2.describeVolumes = sinon.stub().yields(null, ec2Responses.volumes1);
 
 			return ec2Store.listEBS()
-				.then(volumeList => {
+				.then(({volumes}) => {
 					expect(mockEC2.describeVolumes.called).to.be.ok();
 					return;
 				});
@@ -142,9 +142,9 @@ describe('EC2Store', () => {
 			let volListPromise = ec2Store.listEBS();
 
 			expect(volListPromise).to.be.a(Promise);
-			return volListPromise.then(volList => {
-				expect(volList).to.be.an(Array);
-				expect(volList.length).to.not.be(0);
+			return volListPromise.then(({volumes}) => {
+				expect(volumes).to.be.an(Array);
+				expect(volumes.length).to.not.be(0);
 				return;
 			})
 		});
@@ -160,9 +160,9 @@ describe('EC2Store', () => {
 			mockEC2.describeVolumes = sinon.stub().yields(null, ec2Responses.volumes1);
 
 			return ec2Store.listEBS()
-				.then(volList => {
-					expect(volList.length).to.be(3);
-					expect(volList).to.be.eql([
+				.then(({volumes}) => {
+					expect(volumes.length).to.be(3);
+					expect(volumes).to.be.eql([
 						{
 							VolumeId: firstVol.VolumeId,
 							Name: firstVol.Tags[1].Value,
@@ -224,9 +224,9 @@ describe('EC2Store', () => {
 			mockEC2.describeVolumes = sinon.stub().yields(null, ec2Responses.volumes2);
 
 			return ec2Store.listEBS()
-				.then(volList => {
-					expect(volList.length).to.be(2);
-					expect(volList).to.be.eql([
+				.then(({volumes}) => {
+					expect(volumes.length).to.be(2);
+					expect(volumes).to.be.eql([
 						{
 							VolumeId: secondVol.VolumeId,
 							Name: secondVol.Tags[0].Value,

--- a/test/_TestPrinting.js
+++ b/test/_TestPrinting.js
@@ -1,0 +1,115 @@
+import sinon from 'sinon';
+import expect from 'expect.js';
+
+import * as printer from '../src/printing';
+
+describe('Printer', () => {
+
+	let sandbox, mocks;
+
+	beforeEach(() => {
+		sandbox = sinon.sandbox.create();
+		mocks = {};
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	describe('printSnaplist', () => {
+		it('should at least print the SnapshotId and Name of each snapshot', () => {
+			mocks.log = sandbox.stub(console, 'log');
+			printer.printSnaplist([
+				{SnapshotId: '237845', Name: 'franklin'},
+				{SnapshotId: '984752987', Name: 'bob'},
+			]);
+
+			let output = '';
+			mocks.log.args.map(call => {
+				call.map(line => {
+					output += line;
+				})
+			});
+
+			expect(output).to.contain('237845');
+			expect(output).to.contain('franklin');
+			expect(output).to.contain('984752987');
+			expect(output).to.contain('bob');
+		});
+	});
+
+	describe('printEBSList', () => {
+		it('should at least print the VolumeId and Name of each volume', () => {
+			mocks.log = sandbox.stub(console, 'log');
+			printer.printEBSList([
+				{VolumeId: '237845', Name: 'franklin', BackupConfig: { BackupTypes: []}},
+				{VolumeId: '984752987', Name: 'bob', BackupConfig: { BackupTypes: []}},
+			]);
+
+			let output = '';
+			mocks.log.args.map(call => {
+				call.map(line => {
+					output += line;
+				})
+			});
+
+			expect(output).to.contain('237845');
+			expect(output).to.contain('franklin');
+			expect(output).to.contain('984752987');
+			expect(output).to.contain('bob');
+		});
+	});
+
+	describe('printStatistics', () => {
+		it('prints from a statistics object the properties `snapshots`, `volumes` and `backupTypes`', () => {
+			mocks.log = sandbox.stub(console, 'log');
+			printer.printStatistics({snapshots: 984752987, volumes: 82634862, backupTypes: 289174});
+
+			let output = '';
+			mocks.log.args.map(call => {
+				call.map(line => {
+					output += line;
+				})
+			});
+
+			expect(output).to.contain('984752987');
+			expect(output).to.contain('82634862');
+			expect(output).to.contain('289174');
+		});
+	});
+
+	describe('printWarnings', () => {
+		it('prints out the given array to the warn console line by line', () => {
+			mocks.log = sandbox.stub(console, 'warn');
+			printer.printWarnings(['Help!', 'A message!', 'hello!']);
+
+			let output = '';
+			mocks.log.args.map(call => {
+				call.map(line => {
+					output += line;
+				})
+			});
+
+			expect(mocks.log.callCount).to.be.above(3);
+			expect(output).to.contain('Help!');
+			expect(output).to.contain('message!');
+			expect(output).to.contain('hello!');
+		});
+	});
+
+	describe('printError', () => {
+		it('prints the error stack to console', () => {
+			mocks.log = sandbox.stub(console, 'error');
+			printer.printError(new Error('something wrong'));
+
+			let output = '';
+			mocks.log.args.map(call => {
+				call.map(line => {
+					output += line;
+				})
+			});
+
+			expect(output).to.contain('something wrong');
+		});
+	});
+});


### PR DESCRIPTION
Print out information to the console about what snapshots and volumes are tagged for backups.

Prints out totals of each resource and backup types.

Prints warnings about problems with tags on resources